### PR TITLE
change custom event names to kebab style

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,15 +12,15 @@
           </div>
 
           <div class="list-todos-wrapper">
-            <TodoList :todos="todos" @selectionchange="handleDone"
-            @itemdeleted="handleRemove"
-            @itemedit="handleEdit">
+            <TodoList :todos="todos" @selection-change="handleDone"
+            @item-deleted="handleRemove"
+            @item-edit="handleEdit">
             </TodoList>
 
             <ui5-panel header-text="Completed tasks">
-              <TodoList :todos="doneTodos" @selectionchange="handleUndone"
-              @itemdeleted="handleRemove"
-              @itemedit="handleEdit">
+              <TodoList :todos="doneTodos" @selection-change="handleUndone"
+              @item-deleted="handleRemove"
+              @item-edit="handleEdit">
               </TodoList>
             </ui5-panel>
           </div>

--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -18,10 +18,10 @@ let TodoItem = Vue.component('TodoItem', {
   props: ["todo", "datakey"],
   methods: {
     onEditPress() {
-      this.$emit('itemedit', { id: this.todo.id });
+      this.$emit('item-edit', { id: this.todo.id });
     },
     onDeletePress() {
-      this.$emit('itemdeleted', { id: this.todo.id });
+      this.$emit('item-deleted', { id: this.todo.id });
     }
   }
 });

--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -1,8 +1,8 @@
 <template>
   <ui5-list id="todo-list" mode="MultiSelect" ref="list" @selectionChange="onSelectionChange">
     <TodoItem v-for="(todo) in todos" :todo="todo" :key="todo.id" :datakey="todo.id"
-    @itemdeleted="onItemDeleted"
-    @itemedit="onItemEdit">
+    @item-deleted="onItemDeleted"
+    @item-edit="onItemEdit">
     </TodoItem>
   </ui5-list>
 </template>
@@ -17,13 +17,13 @@ let TodoList = Vue.component('TodoList', {
   props: ["todos"],
   methods: {
     onSelectionChange(event) {
-      this.$emit('selectionchange', event);
+      this.$emit('selection-change', event);
     },
     onItemDeleted(event) {
-      this.$emit('itemdeleted', event);
+      this.$emit('item-deleted', event);
     },
     onItemEdit(event) {
-      this.$emit('itemedit', event);
+      this.$emit('item-edit', event);
     }
   }
 });


### PR DESCRIPTION
Currently the Vue custom event names were not using kebab style, it will cause some confusions with the native UI5 event names.

e.g. in **ui5-list,** the event @selectionChange is very similar to the custom event @selectionchange

it is recommended always using kebab style for Vue custom event names:
https://vuejs.org/v2/guide/components-custom-events.html