### PR TITLE
chore(ci): add explicit GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,10 @@ name: Deploy
 on:
   push:
     branches: [ main ]
+
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add explicit top-level `permissions:` blocks to all GitHub Actions workflows to follow the principle of least privilege and prepare for GitHub's upcoming enforcement of read-only default `GITHUB_TOKEN` permissions.

## Permissions Applied

| Workflow | Permission | Reason |
|----------|-----------|--------|
| `ci.yml` | `contents: read` | Only checks out code and runs build — no write access needed |
| `lint.yml` | `contents: read` | Only checks out code and runs linting — no write access needed |
| `deploy.yml` | `contents: write` | Uses `JamesIves/github-pages-deploy-action` which pushes the built artifacts to the `gh-pages` branch |

## Context

GitHub is enforcing read-only as the default permission for `GITHUB_TOKEN` in all new repositories, and will roll this out more broadly. Adding explicit permissions ensures workflows continue to function correctly after this change, and documents the intended access level for each workflow.