### PR TITLE
fix(ci): upgrade Node to 22 and actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v4
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Build
         run: |
           npm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         cache: 'npm'
 
     - name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,12 +18,12 @@ jobs:
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v4
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Lint
         run: |
           npm install


### PR DESCRIPTION
## Summary

The CI was failing with:
```
Cannot find module @rollup/rollup-linux-x64-gnu
```

This is a [known npm bug](https://github.com/npm/cli/issues/4828) where optional native dependencies (like Rollup's platform-specific binaries) are not correctly resolved when using older Node.js versions with a stale lockfile on Linux runners.

## Changes

- **actions/checkout**: `v2.4.0` / `v3` → `v4` (all workflows)
- **actions/setup-node**: `v2.4.1` / `v3` → `v4` (all workflows)
- **Node.js version**: `20` → `22` (all workflows)

## Why this fixes the issue

Node 22 ships with npm 10.x which correctly handles optional peer dependencies and platform-specific packages like `@rollup/rollup-linux-x64-gnu`. The updated GitHub Actions versions also provide better caching and compatibility with modern runners.

## Affected workflows

- `.github/workflows/ci.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/lint.yml`

## Note

The `package-lock.json` was not regenerated in this PR. If the issue persists after this change, regenerating the lockfile with Node 22 locally would be the next step.